### PR TITLE
Small formatting fixes

### DIFF
--- a/_tutorial/02-jsx.md
+++ b/_tutorial/02-jsx.md
@@ -33,8 +33,8 @@ console.log('Server running at http://localhost:1337/')
 ## Get the react-tools installed
 This will allow us to use React's JSX syntax and compile it to raw JS
 
-1. npm install --global react-tools
-1. npm install --save-dev react-tools
+1. `npm install react-tools --global`
+1. `npm install react-tools --save-dev`
 
 ## Compile the JSX manually
 Now if you run `jsx index.jsx > index.js` the JSX file will be compiled into raw JavaScript.  The output will match the following.

--- a/_tutorial/03-gulp-workflow.md
+++ b/_tutorial/03-gulp-workflow.md
@@ -5,8 +5,8 @@ step: 3
 ---
 After running JSX manually once, it's pretty clear that we won't want to keep running that every time we make a change.  Instead of running `JSX` and then `Node` over and over again, we'll use Gulp to automatically run JSX and Node for us.
 
-1. `npm install --global gulp`
-1. `npm install --save-dev gulp`
+1. `npm install gulp --global`
+1. `npm install gulp --save-dev`
 
 We'll need to create a `gulpfile.js` at the root of our project.  Let's start with their skeleton:
 

--- a/_tutorial/05-gulp-restart.md
+++ b/_tutorial/05-gulp-restart.md
@@ -27,7 +27,7 @@ gulp.task('default', function() {
 
 Gulp's piping make this really clean.  And we can now use `gulp-nodemon` to take care of running Node for us.
 
-1. npm install gulp-nodemon --save-dev
+1. 'npm install gulp-nodemon --save-dev'
 
 With this package in place, we can easily get Node to restart whenever a JS file is updated.  Here's our new `gulpfile.js` with that plugged in.
 

--- a/_tutorial/06-gulp-complete.md
+++ b/_tutorial/06-gulp-complete.md
@@ -5,8 +5,8 @@ step: 6
 ---
 To bring this all together, we need to get Gulp to watch our `index.jsx` file and call our `jsx` task whenever the file is touched. Then we'll be able to run Gulp once and freely edit the `index.jsx` file and have the changes pick up automatically. First you'll need to install Gulp Watch:
 
-1. 'npm install gulp-watch --save-dev'
-2. Then make the following changes to 'gulpfile.js':
+1. `npm install gulp-watch --save-dev`
+2. Then make the following changes to `gulpfile.js`:
 
 <pre class="brush: js">
 var gulp = require('gulp')

--- a/_tutorial/06-gulp-complete.md
+++ b/_tutorial/06-gulp-complete.md
@@ -3,7 +3,10 @@ layout: default
 title: Complete Gulp Workflow
 step: 6
 ---
-To bring this all together, we need to get Gulp to watch our `index.jsx` file and call our `jsx` task whenever the file is touched. Then we run Gulp once and freely edit the `index.jsx` file and have the changes pick up automatically.
+To bring this all together, we need to get Gulp to watch our `index.jsx` file and call our `jsx` task whenever the file is touched. Then we'll be able to run Gulp once and freely edit the `index.jsx` file and have the changes pick up automatically. First you'll need to install Gulp Watch:
+
+1. 'npm install gulp-watch --save-dev'
+2. Then make the following changes to 'gulpfile.js':
 
 <pre class="brush: js">
 var gulp = require('gulp')


### PR DESCRIPTION
Clean up of several npm install commands to have quotes so the double hyphen '--' in the scope command is obvious, and moving the scope to the end

Also added instruction to install gulp-watch.
